### PR TITLE
Node initialiser with options for syntax extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: swift
-osx_image: xcode9.3
+osx_image: xcode10
 script:
-  - xcodebuild clean test -project cmark-gfm-swift.xcodeproj -scheme cmark-gfm-swift -destination "platform=iOS Simulator,name=iPhone X,OS=11.3" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO -quiet
+  - xcodebuild clean test -project cmark-gfm-swift.xcodeproj -scheme cmark-gfm-swift -destination "platform=iOS Simulator,name=iPhone X,OS=12.0" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO -quiet

--- a/Source/Node.swift
+++ b/Source/Node.swift
@@ -41,7 +41,7 @@ extension String {
 /// just some part of a document.
 public class Node: CustomStringConvertible {
     
-    public enum Option: String {
+    public enum Option: String, CaseIterable {
         
         case autolink, checkbox, mention, strikethrough, table
     }
@@ -58,11 +58,9 @@ public class Node: CustomStringConvertible {
         guard let parser = cmark_parser_new(0) else { return nil }
         defer { cmark_parser_free(parser) }
         
-        options.forEach {
-            if let ext = cmark_find_syntax_extension($0.rawValue) {
-                cmark_parser_attach_syntax_extension(parser, ext)
-            }
-        }
+        options
+            .compactMap { cmark_find_syntax_extension($0.rawValue) }
+            .forEach { cmark_parser_attach_syntax_extension(parser, $0) }
         
         cmark_parser_feed(parser, markdown, markdown.utf8.count)
         guard let node = cmark_parser_finish(parser) else { return nil }
@@ -71,8 +69,7 @@ public class Node: CustomStringConvertible {
     
     public convenience init?(markdown: String) {
         
-        let allOptions: [Option] = [.autolink, .checkbox, .mention, .strikethrough, .table]
-        self.init(markdown: markdown, options: allOptions)
+        self.init(markdown: markdown, options: Option.allCases)
     }
     
     deinit {

--- a/cmark-gfm-swift.podspec
+++ b/cmark-gfm-swift.podspec
@@ -19,10 +19,10 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
 
-  s.source_files = 'Source/**/*.swift', 'Source/**/*.c', 'Source/**/*.h'
+  s.source_files = 'Source/**/*.swift', 'Source/**/*.c', 'Source/**/*.h', 'Source/**/*.inc'
   s.public_header_files = 'Source/*.h'
   s.exclude_files = "Source/Info.plist"
-  s.preserve_path = 'Source/cmark_gfm/module.modulemap'
+  s.preserve_paths = 'Source/cmark_gfm/module.modulemap', 'Source/cmark_gfm/scanners.re'
   s.pod_target_xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/cmark-gfm-swift/Source/cmark_gfm/**' }
 
 end

--- a/cmark-gfm-swift.podspec
+++ b/cmark-gfm-swift.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
 
-  s.source_files = 'Source/**/*'
+  s.source_files = 'Source/**/*.swift', 'Source/**/*.c', 'Source/**/*.h'
   s.public_header_files = 'Source/*.h'
   s.exclude_files = "Source/Info.plist"
   s.preserve_path = 'cmark-gfm-swift/Source/cmark_gfm/module.modulemap'

--- a/cmark-gfm-swift.podspec
+++ b/cmark-gfm-swift.podspec
@@ -22,6 +22,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Source/**/*.swift', 'Source/**/*.c', 'Source/**/*.h'
   s.public_header_files = 'Source/*.h'
   s.exclude_files = "Source/Info.plist"
+  s.header_mappings_dir = 'Source/cmark_gfm'
   s.preserve_path = 'cmark-gfm-swift/Source/cmark_gfm/module.modulemap'
   s.pod_target_xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/cmark-gfm-swift/Source/cmark_gfm/**' }
 

--- a/cmark-gfm-swift.podspec
+++ b/cmark-gfm-swift.podspec
@@ -22,8 +22,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Source/**/*.swift', 'Source/**/*.c', 'Source/**/*.h'
   s.public_header_files = 'Source/*.h'
   s.exclude_files = "Source/Info.plist"
-  s.header_mappings_dir = 'Source/cmark_gfm'
-  s.preserve_path = 'cmark-gfm-swift/Source/cmark_gfm/module.modulemap'
+  s.preserve_path = 'Source/cmark_gfm/module.modulemap'
   s.pod_target_xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/cmark-gfm-swift/Source/cmark_gfm/**' }
 
 end

--- a/cmark-gfm-swift.xcodeproj/project.pbxproj
+++ b/cmark-gfm-swift.xcodeproj/project.pbxproj
@@ -443,15 +443,17 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 0920;
+				LastUpgradeCheck = 1010;
 				ORGANIZATIONNAME = "Ryan Nystrom";
 				TargetAttributes = {
 					2911C5602070879600732441 = {
 						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 					};
 					29C28E362070A6F4002C19F7 = {
 						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -582,6 +584,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -589,6 +592,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -642,6 +646,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -649,6 +654,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -675,6 +681,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -699,7 +706,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/Source/cmark_gfm";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -721,7 +728,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/Source/cmark_gfm";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -735,7 +742,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.whoisryannystrom.cmark-gfm-swiftTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -749,7 +756,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.whoisryannystrom.cmark-gfm-swiftTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/cmark-gfm-swift.xcodeproj/project.pbxproj
+++ b/cmark-gfm-swift.xcodeproj/project.pbxproj
@@ -34,8 +34,6 @@
 		29C28DF32070A5EF002C19F7 /* latex.c in Sources */ = {isa = PBXBuildFile; fileRef = 29C28DAE2070A5EF002C19F7 /* latex.c */; };
 		29C28DF42070A5EF002C19F7 /* houdini_href_e.c in Sources */ = {isa = PBXBuildFile; fileRef = 29C28DAF2070A5EF002C19F7 /* houdini_href_e.c */; };
 		29C28DF52070A5EF002C19F7 /* syntax_extension.c in Sources */ = {isa = PBXBuildFile; fileRef = 29C28DB02070A5EF002C19F7 /* syntax_extension.c */; };
-		29C28DF62070A5EF002C19F7 /* case_fold_switch.inc in Sources */ = {isa = PBXBuildFile; fileRef = 29C28DB12070A5EF002C19F7 /* case_fold_switch.inc */; };
-		29C28DF72070A5EF002C19F7 /* entities.inc in Sources */ = {isa = PBXBuildFile; fileRef = 29C28DB22070A5EF002C19F7 /* entities.inc */; };
 		29C28DF82070A5EF002C19F7 /* ext_scanners.c in Sources */ = {isa = PBXBuildFile; fileRef = 29C28DB32070A5EF002C19F7 /* ext_scanners.c */; };
 		29C28DF92070A5EF002C19F7 /* tagfilter.c in Sources */ = {isa = PBXBuildFile; fileRef = 29C28DB42070A5EF002C19F7 /* tagfilter.c */; };
 		29C28DFA2070A5EF002C19F7 /* houdini_html_e.c in Sources */ = {isa = PBXBuildFile; fileRef = 29C28DB52070A5EF002C19F7 /* houdini_html_e.c */; };
@@ -525,9 +523,7 @@
 				29C28E272070A5EF002C19F7 /* houdini_html_u.c in Sources */,
 				29C28DF12070A5EF002C19F7 /* table.c in Sources */,
 				29C28E232070A5EF002C19F7 /* html.c in Sources */,
-				29C28DF72070A5EF002C19F7 /* entities.inc in Sources */,
 				29C286FB207087CF002C19F7 /* Block+TextElement.swift in Sources */,
-				29C28DF62070A5EF002C19F7 /* case_fold_switch.inc in Sources */,
 				29C286F9207087CF002C19F7 /* Inline+TextElement.swift in Sources */,
 				29C286ED207087CF002C19F7 /* Block+TableRow.swift in Sources */,
 				29C28E1E2070A5EF002C19F7 /* iterator.c in Sources */,

--- a/cmark-gfm-swift.xcodeproj/xcshareddata/xcschemes/cmark-gfm-swift.xcscheme
+++ b/cmark-gfm-swift.xcodeproj/xcshareddata/xcschemes/cmark-gfm-swift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "1010"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/cmark-gfm-swift.xcodeproj/xcshareddata/xcschemes/cmark_gfm_swiftTests.xcscheme
+++ b/cmark-gfm-swift.xcodeproj/xcshareddata/xcschemes/cmark_gfm_swiftTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "1010"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Adds a Node initialiser to specify extensions to enable. For instance, it lets you disable GitHub mentions on apps unrelated to GitHub.

It also 
- Migrates the project to 4.2
- Removes *.inc files from Sources that were causing warnings on Xcode.
- Updates Travis to Xcode 10 and iOS 12.0