### PR TITLE
Add support for footnotes

### DIFF
--- a/Source/Node.swift
+++ b/Source/Node.swift
@@ -49,7 +49,7 @@ public class Node: CustomStringConvertible {
     public init?(markdown: String) {
         core_extensions_ensure_registered()
 
-        guard let parser = cmark_parser_new(0) else { return nil }
+        guard let parser = cmark_parser_new(CMARK_OPT_FOOTNOTES) else { return nil }
         defer { cmark_parser_free(parser) }
 
         if let ext = cmark_find_syntax_extension("table") {

--- a/cmark_gfm_swiftTests/Tests.swift
+++ b/cmark_gfm_swiftTests/Tests.swift
@@ -84,7 +84,7 @@ class Tests: XCTestCase {
         let blocks = rootNode.elements
         XCTAssertEqual(blocks.count, 1)
     }
-
+    
     func testMarkdownCodeBlock() {
         let markdown = """
             ```swift
@@ -368,6 +368,27 @@ class Tests: XCTestCase {
         XCTAssertEqual(cells[1].string, "bim")
     }
 
+    func testFootnotes() {
+        let markdown = """
+            Lorem ipsum[^1]
+            [^1]: Test footnote
+            """
+        let html = Node(markdown: markdown)!.html
+        let expected = """
+            <p>Lorem ipsum<sup class="footnote-ref"><a href="#fn1" id="fnref1">1</a></sup></p>
+            <section class="footnotes">
+            <ol>
+            <li id="fn1">
+            <p>Test footnote <a href="#fnref1" class="footnote-backref">↩</a></p>
+            </li>
+            </ol>
+            </section>
+
+            """
+        XCTAssertEqual(html, expected)
+        
+    }
+    
     func testEmailNotAMention() {
         let markdown = "me@google"
         let node = Node(markdown: markdown)!


### PR DESCRIPTION
#13 

- Add support for foot ntoe
  - Adding `CMARK_OPT_FOOTNOTES` to `cmark_parser_new` renders footnotes syntax.
  - If you don't want to change default option (0), there should be additional API for giving options.
- Add an unittest for footnote rendering.
- I've tried to add some AST thing, but there is no entry for footnotes in [GFM spec](https://github.github.com/gfm/). So, I did not add it.
